### PR TITLE
[removeTrackingUrl] Fixed Missing Logger Import Breaking Plugin Functionality

### DIFF
--- a/plugins/dist/removeTrackingURL.plugin.js
+++ b/plugins/dist/removeTrackingURL.plugin.js
@@ -95,7 +95,7 @@ if (!global.ZeresPluginLibrary) {
 module.exports = !global.ZeresPluginLibrary ? Dummy : (([Plugin, Api]) => {
      const plugin = (Plugin, Library) => {
 
-    const { DiscordModules, Patcher, Settings, Toasts } = Library;
+    const { DiscordModules, Logger, Patcher, Settings, Toasts } = Library;
     const { Dispatcher } = DiscordModules;
 
     const REGEX = {

--- a/plugins/src/removeTrackingURL/index.js
+++ b/plugins/src/removeTrackingURL/index.js
@@ -6,7 +6,7 @@
  */
 module.exports = (Plugin, Library) => {
 
-    const { DiscordModules, Patcher, Settings, Toasts } = Library;
+    const { DiscordModules, Logger, Patcher, Settings, Toasts } = Library;
     const { Dispatcher } = DiscordModules;
 
     const REGEX = {


### PR DESCRIPTION
Looks like the logger got removed from the tacker removal plugin after the update for X links. Not sure if it was intentional to be removed, but from what I could tell removing it from the import list was causing the plugin to not properly initialize on start as well as unload. Added it back in to restore the functionality instead of removing all uses of the logger since it looks like it was being used to help with debugging.